### PR TITLE
Update for hc rust [stage 1]

### DIFF
--- a/test/hClientTests.js
+++ b/test/hClientTests.js
@@ -1,0 +1,48 @@
+describe("hClient: basic test", () => {
+
+  it("should be able to override window.holochainClient", async () => {
+
+  	// mock holochainClient
+  	window.holochainClient = {
+  		connect: (url) => new Promise((resolve) => {
+  			console.log("connecting to ", url)
+
+  			resolve({
+  				call: (callString) => (params) => new Promise((resolve) => {
+  					console.log(`${callString} was called with ${params}`);
+  					resolve("original result");
+  				})
+  			});
+  		})
+  	}
+
+  	// make a call with the original mock
+  	let firstCallResult;
+  	await window.holochainClient.connect("url1").then(({call}) => {
+  		call("callString1")("params1").then(result => {
+  			console.log(result)
+  			firstCallResult = result
+  		});
+  	});
+  	expect(firstCallResult).toBe("original result");
+
+
+  	// use hClient to override
+  	const url = "ws://test"
+  	const preCall = (callString, params) => ({callString, params});
+  	const postCall = response => response;
+  	hClient.overrideWebClient(url, preCall, postCall);
+
+	// make a call with the overriden version
+  	let secondCallResult;
+  	await window.holochainClient.connect().then(({call}) => {
+  		call("callString1")("params1").then(result => {
+  			console.log(result)
+  			secondCallResult = result
+  		});
+  	});
+  	expect(secondCallResult).toBe("original result");
+
+
+  })
+})

--- a/test/hClientTests.js
+++ b/test/hClientTests.js
@@ -26,12 +26,16 @@ describe("hClient: basic test", () => {
   	});
   	expect(firstCallResult).toBe("original result");
 
+  	
+
 
   	// use hClient to override
   	const url = "ws://test"
   	const preCall = (callString, params) => ({callString, params});
-  	const postCall = response => response;
+  	const postCall = response => "override response";
   	hClient.overrideWebClient(url, preCall, postCall);
+
+
 
 	// make a call with the overriden version
   	let secondCallResult;
@@ -41,7 +45,7 @@ describe("hClient: basic test", () => {
   			secondCallResult = result
   		});
   	});
-  	expect(secondCallResult).toBe("original result");
+  	expect(secondCallResult).toBe("override response");
 
 
   })

--- a/test/hClientTests.js
+++ b/test/hClientTests.js
@@ -33,7 +33,7 @@ describe("hClient: basic test", () => {
   	const url = "ws://test"
   	const preCall = (callString, params) => ({callString, params});
   	const postCall = response => "override response";
-  	const postConnect = ws => {};
+  	const postConnect = ws => ws;
   	hClient.overrideWebClient(url, preCall, postCall, postConnect);
 
 

--- a/test/hClientTests.js
+++ b/test/hClientTests.js
@@ -33,7 +33,8 @@ describe("hClient: basic test", () => {
   	const url = "ws://test"
   	const preCall = (callString, params) => ({callString, params});
   	const postCall = response => "override response";
-  	hClient.overrideWebClient(url, preCall, postCall);
+  	const postConnect = ws => {};
+  	hClient.overrideWebClient(url, preCall, postCall, postConnect);
 
 
 

--- a/test/hQueryTests.js
+++ b/test/hQueryTests.js
@@ -1,10 +1,10 @@
-describe("addConnectionUrlScript", () => {
+describe("insertScripts", () => {
 
-  it("should add a <script> tag to an empty html document", () => {
+  it("should add the correct override script to a simple HTML string", () => {
   	htmlString = "<html><body>original content</body></html>"
-  	newString = addConnectionUrlScript(htmlString, "ws://")
+  	newString = insertScripts(htmlString, "ws://")
     expect(newString)
-    	.toBe("<html><head><script>window.holochainUrl=ws://</script></head><body>original content</body></html>");
+    	.toBe(`<html><head><script src="hClient.js">hClient.overrideWebClient(ws://)</script></head><body>original content</body></html>`);
   })
 
 })

--- a/test/hQueryTests.js
+++ b/test/hQueryTests.js
@@ -1,10 +1,9 @@
-describe("insertScripts", () => {
+describe("hQuery: insertScripts", () => {
 
   it("should add the correct override script to a simple HTML string", () => {
   	htmlString = "<html><body>original content</body></html>"
-  	newString = insertScripts(htmlString, "ws://")
+  	newString = hQuery.insertScripts(htmlString, "ws://")
     expect(newString)
     	.toBe(`<html><head><script src="hClient.js">hClient.overrideWebClient(ws://)</script></head><body>original content</body></html>`);
   })
-
 })

--- a/test/hQueryTests.js
+++ b/test/hQueryTests.js
@@ -1,0 +1,10 @@
+describe("addConnectionUrlScript", () => {
+
+  it("should add a <script> tag to an empty html document", () => {
+  	htmlString = "<html><body>original content</body></html>"
+  	newString = addConnectionUrlScript(htmlString, "ws://")
+    expect(newString)
+    	.toBe("<html><head><script>window.holochainUrl=ws://</script></head><body>original content</body></html>");
+  })
+
+})

--- a/test/testRunner.html
+++ b/test/testRunner.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Testing with Jasmine</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine-html.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/boot.min.js"></script>
+    <script src="../web/hQuery.js"></script>
+    <script src="hQueryTests.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/testRunner.html
+++ b/test/testRunner.html
@@ -6,8 +6,13 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine-html.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/boot.min.js"></script>
+    
     <script src="../web/hQuery.js"></script>
     <script src="hQueryTests.js"></script>
+
+    <script src="../web/hClient.js"></script>
+    <script src="hClientTests.js"></script>
+
 </head>
 <body>
 </body>

--- a/web/hClient.js
+++ b/web/hClient.js
@@ -13,10 +13,40 @@ const hClient = (function(){
 
     const overrideWebClient = (url) => {
         const holochainClient = win.holochainClient;
-        
+
         win.holochainClient = {
-            connect: holochainClient.connect(url)
+            connect: holochainClient.connect(url).then(({call, close, ws}) => {
+                return {
+                    call: (callString) => (params) => {
+                        let {callString, params} = preCall(callString, params);
+                        return call(callString)(params).then(postCall);
+                    },
+                    close: () => {},
+                    ws: () => {},
+                }
+            })
         };
+    }
+
+    /**
+     * Preprocesses the callString and params before making a call
+     *
+     * @param      {string}  callString  The call string e.g. dna/zome/function
+     * @param      {Object}  params      The parameters 
+     * @return     {callString, params}  The updated callString and params passed to call
+     */
+    const preCall = (callString, params) => {
+        return {callString, params};
+    }
+
+    /**
+     * Postprocess the response of a call before returning it to the UI
+     *
+     * @param      {string}  response  The response of the call
+     * @return     {string}  Updated response
+     */
+    const postCall = (response) => {
+        return response;
     }
 
     return {

--- a/web/hClient.js
+++ b/web/hClient.js
@@ -1,0 +1,26 @@
+/**
+ * hClient.js
+ * An API compatible drop-in for hc-web-client
+ * 
+ * Exports a single function, overrideWebClient, that will instantly holo-ify a holochain app.
+ * It adds the additional functionality of
+ *     - Connecting to the correct holo-port
+ *     - Signing all calls with the agents private key
+ *     - Intercepting 401 responses to display a login screen
+ */
+
+const hClient = (function(){
+
+    const overrideWebClient = (url) => {
+        const holochainClient = win.holochainClient;
+        
+        win.holochainClient = {
+            connect: holochainClient.connect(url)
+        };
+    }
+
+    return {
+        overrideWebClient
+    };
+
+})();

--- a/web/hClient.js
+++ b/web/hClient.js
@@ -19,16 +19,14 @@ const hClient = (function(){
      * @param      {<type>}    url       The url to connect to
      * @param      {Function}  preCall   The pre call funciton. Takes the callString and params and returns new callString and params
      * @param      {Function   postCall  The post call function. Takes the response and returns the new response
-     * @param      {Function   postConnect  The post connect function. Takes a RPC-websockets object
+     * @param      {Function   postConnect  The post connect function. Takes a RPC-websockets object and returns it
      */
     const overrideWebClient = (url, preCall, postCall, postConnect) => {
         const holochainClient = window.holochainClient;
 
         window.holochainClient = {
             connect: () => holochainClient.connect(url).then(({call, close, ws}) => {
-                // TODO: Add callbacks to the ws object for signing entries as the interceptor requests it
-                // This is sketchy AF but ok for closed alpha until we get a lite client
-                postConnect(ws);
+                ws = postConnect(ws);
                 return {
                     call: (callString) => (params) => {
                         const {callString: newCallString, params: newParams} = preCall(callString, params);
@@ -72,7 +70,13 @@ const hClient = (function(){
      * @param      {<type>}  ws      { rpc=websockets object }
      */
     const postConnect = (ws) => {
-
+        // TODO: subscribe to a rpc-websocket callback for sigining actions
+        // e.g.
+        // ws.subscribe("sign_entry");
+        // ws.on("sign_entry", () => {
+        //     // Sign the response and then send it back to the interceptor
+        // });
+        return ws;
     }
 
     return {

--- a/web/hClient.js
+++ b/web/hClient.js
@@ -11,43 +11,53 @@
 
 const hClient = (function(){
 
-    const overrideWebClient = (url) => {
-        const holochainClient = win.holochainClient;
 
-        win.holochainClient = {
-            connect: holochainClient.connect(url).then(({call, close, ws}) => {
+    /**
+     * Wraps and overwrites the current holochainClient attached to the window
+     * Keeps the same functionaltiy but adds preCall and postCall hooks and also forces
+     * connect to go to a given URL
+     *
+     * @param      {<type>}    url       The url to connect to
+     * @param      {Function}  preCall   The pre call funciton
+     * @param      {Function   postCall  The post call function
+     */
+    const overrideWebClient = (url, preCall, postCall) => {
+        const holochainClient = window.holochainClient;
+
+        window.holochainClient = {
+            connect: () => holochainClient.connect(url).then(({call, close, ws}) => {
                 return {
                     call: (callString) => (params) => {
-                        let {callString, params} = preCall(callString, params);
-                        return call(callString)(params).then(postCall);
+                        const {callString: newCallString, params: newParams} = preCall(callString, params);
+                        return call(newCallString)(newParams).then(postCall);
                     },
-                    close: () => {},
-                    ws: () => {},
+                    close,
+                    ws,
                 }
             })
         };
     }
 
-    /**
-     * Preprocesses the callString and params before making a call
-     *
-     * @param      {string}  callString  The call string e.g. dna/zome/function
-     * @param      {Object}  params      The parameters 
-     * @return     {callString, params}  The updated callString and params passed to call
-     */
-    const preCall = (callString, params) => {
-        return {callString, params};
-    }
+    // /**
+    //  * Preprocesses the callString and params before making a call
+    //  *
+    //  * @param      {string}  callString  The call string e.g. dna/zome/function
+    //  * @param      {Object}  params      The parameters 
+    //  * @return     {callString, params}  The updated callString and params passed to call
+    //  */
+    // const preCall = (callString, params) => {
+    //     return {callString, params};
+    // }
 
-    /**
-     * Postprocess the response of a call before returning it to the UI
-     *
-     * @param      {string}  response  The response of the call
-     * @return     {string}  Updated response
-     */
-    const postCall = (response) => {
-        return response;
-    }
+    // /**
+    //  * Postprocess the response of a call before returning it to the UI
+    //  *
+    //  * @param      {string}  response  The response of the call
+    //  * @return     {string}  Updated response
+    //  */
+    // const postCall = (response) => {
+    //     return response;
+    // }
 
     return {
         overrideWebClient

--- a/web/hClient.js
+++ b/web/hClient.js
@@ -17,16 +17,18 @@ const hClient = (function(){
      * connect to go to a given URL
      *
      * @param      {<type>}    url       The url to connect to
-     * @param      {Function}  preCall   The pre call funciton
-     * @param      {Function   postCall  The post call function
+     * @param      {Function}  preCall   The pre call funciton. Takes the callString and params and returns new callString and params
+     * @param      {Function   postCall  The post call function. Takes the response and returns the new response
+     * @param      {Function   postConnect  The post connect function. Takes a RPC-websockets object
      */
-    const overrideWebClient = (url, preCall, postCall) => {
+    const overrideWebClient = (url, preCall, postCall, postConnect) => {
         const holochainClient = window.holochainClient;
 
         window.holochainClient = {
             connect: () => holochainClient.connect(url).then(({call, close, ws}) => {
                 // TODO: Add callbacks to the ws object for signing entries as the interceptor requests it
                 // This is sketchy AF but ok for closed alpha until we get a lite client
+                postConnect(ws);
                 return {
                     call: (callString) => (params) => {
                         const {callString: newCallString, params: newParams} = preCall(callString, params);
@@ -62,6 +64,15 @@ const hClient = (function(){
         // TODO: Sign the response and sent it back to the interceptor
         // TODO: Unpack the response to expose to the UI code (make it look like a regular holochain call)
         return response;
+    }
+
+    /**
+     * Add any new callbacks to the websocket object or make calls immediatly after connecting
+     *
+     * @param      {<type>}  ws      { rpc=websockets object }
+     */
+    const postConnect = (ws) => {
+
     }
 
     return {

--- a/web/hClient.js
+++ b/web/hClient.js
@@ -11,7 +11,6 @@
 
 const hClient = (function(){
 
-
     /**
      * Wraps and overwrites the current holochainClient attached to the window
      * Keeps the same functionaltiy but adds preCall and postCall hooks and also forces
@@ -26,6 +25,8 @@ const hClient = (function(){
 
         window.holochainClient = {
             connect: () => holochainClient.connect(url).then(({call, close, ws}) => {
+                // TODO: Add callbacks to the ws object for signing entries as the interceptor requests it
+                // This is sketchy AF but ok for closed alpha until we get a lite client
                 return {
                     call: (callString) => (params) => {
                         const {callString: newCallString, params: newParams} = preCall(callString, params);
@@ -38,26 +39,30 @@ const hClient = (function(){
         };
     }
 
-    // /**
-    //  * Preprocesses the callString and params before making a call
-    //  *
-    //  * @param      {string}  callString  The call string e.g. dna/zome/function
-    //  * @param      {Object}  params      The parameters 
-    //  * @return     {callString, params}  The updated callString and params passed to call
-    //  */
-    // const preCall = (callString, params) => {
-    //     return {callString, params};
-    // }
+    /**
+     * Preprocesses the callString and params before making a call
+     *
+     * @param      {string}  callString  The call string e.g. dna/zome/function
+     * @param      {Object}  params      The parameters 
+     * @return     {callString, params}  The updated callString and params passed to call
+     */
+    const preCall = (callString, params) => {
+        // TODO: sign the call and add the signature to the params object
+        return {callString, params};
+    }
 
-    // /**
-    //  * Postprocess the response of a call before returning it to the UI
-    //  *
-    //  * @param      {string}  response  The response of the call
-    //  * @return     {string}  Updated response
-    //  */
-    // const postCall = (response) => {
-    //     return response;
-    // }
+    /**
+     * Postprocess the response of a call before returning it to the UI
+     *
+     * @param      {string}  response  The response of the call
+     * @return     {string}  Updated response
+     */
+    const postCall = (response) => {
+        // TODO: Check response for authentication error to see if login is required
+        // TODO: Sign the response and sent it back to the interceptor
+        // TODO: Unpack the response to expose to the UI code (make it look like a regular holochain call)
+        return response;
+    }
 
     return {
         overrideWebClient

--- a/web/hQuery.js
+++ b/web/hQuery.js
@@ -178,21 +178,7 @@ const hQuery = (function(){
         document.close();
     }
 
-    /**
-     * Adds a tiny script in the new document that sets window.holochainUrl which is later detected
-     * by the hc-web-client to redirect calls
-     *
-     * @param {string} html Html to add tag to
-     * @param {string} url hostname (with protocol and port, e.g. //test.holo.host:4141")
-     * @return {string} Html with new script tag inserted at the top level
-     */
-    const addConnectionUrlScript = (html, url) => {
-        parser = new DOMParser();
-        doc = parser.parseFromString(html, "text/html");
-        var script = doc.createElement('script');
-        doc.head.appendChild(script);
-        return doc.documentElement.outerHTML
-    }
+
 
     /**
      * (DEPRECATED)
@@ -213,7 +199,25 @@ const hQuery = (function(){
         initHapp: initHapp,
         getHappUrl: getHappUrl,
         getHappDna: getHappDna
-    // }
+    }
 })();
+
+
+/**
+ * Adds a tiny script in the new document that sets window.holochainUrl which is later detected
+ * by the hc-web-client to redirect calls
+ *
+ * @param {string} html Html to add tag to
+ * @param {string} url hostname (with protocol and port, e.g. //test.holo.host:4141")
+ * @return {string} Html with new script tag inserted at the top level
+ */
+const addConnectionUrlScript = (html, url) => {
+    parser = new DOMParser();
+    doc = parser.parseFromString(html, "text/html");
+    var script = doc.createElement("script");
+    script.innerHTML = "window.holochainUrl=" + url;
+    doc.head.appendChild(script);
+    return doc.documentElement.outerHTML
+}
 
 console.log("hQuery loaded");

--- a/web/hQuery.js
+++ b/web/hQuery.js
@@ -172,13 +172,30 @@ const hQuery = (function(){
      * @return null
      */
     const replaceHtml = (html, addr) => {
-        html = addBaseRaw(html, addr);
+        html = addConnectionUrlScript(html, addr);
         document.open();
         document.write(html);
         document.close();
     }
 
     /**
+     * Adds a tiny script in the new document that sets window.holochainUrl which is later detected
+     * by the hc-web-client to redirect calls
+     *
+     * @param {string} html Html to add tag to
+     * @param {string} url hostname (with protocol and port, e.g. //test.holo.host:4141")
+     * @return {string} Html with new script tag inserted at the top level
+     */
+    const addConnectionUrlScript = (html, url) => {
+        parser = new DOMParser();
+        doc = parser.parseFromString(html, "text/html");
+        var script = doc.createElement('script');
+        doc.head.appendChild(script);
+        return doc.documentElement.outerHTML
+    }
+
+    /**
+     * (DEPRECATED)
      * Add <base> tag that defines host for relative urls on page
      * @param {string} html Html to add tag to
      * @param {string} url hostname (with protocol and port, e.g. //test.holo.host:4141")
@@ -196,7 +213,7 @@ const hQuery = (function(){
         initHapp: initHapp,
         getHappUrl: getHappUrl,
         getHappDna: getHappDna
-    }
+    // }
 })();
 
 console.log("hQuery loaded");

--- a/web/hQuery.js
+++ b/web/hQuery.js
@@ -189,8 +189,8 @@ const hQuery = (function(){
 
 
 /**
- * Adds a tiny script in the new document that sets window.holochainUrl which is later detected
- * by the hc-web-client to redirect calls. At the moment this adds the websocket 
+ * Adds a script that imports hClient and overrides the window web client.
+ * Effectively enables a holochain app to be holo compatible
  *
  * @param {string} html Html to add tag to
  * @param {string} url hostname (with protocol and port, e.g. //test.holo.host:4141")

--- a/web/hQuery.js
+++ b/web/hQuery.js
@@ -179,33 +179,37 @@ const hQuery = (function(){
         document.close();
     }
 
+
+    /**
+     * Adds a script that imports hClient and overrides the window web client.
+     * Effectively enables a holochain app to be holo compatible
+     *
+     * @param {string} html Html to add tag to
+     * @param {string} url hostname (with protocol and port, e.g. //test.holo.host:4141")
+     * @return {string} Html with new script tag inserted at the top level
+     */
+    const insertScripts = (html, url) => {
+        parser = new DOMParser();
+        doc = parser.parseFromString(html, "text/html");
+
+        let script = doc.createElement("script");
+        script.src = "hClient.js"
+        script.innerHTML = `hClient.overrideWebClient(${url})`;
+
+        doc.head.appendChild(script);
+        return doc.documentElement.outerHTML
+    }
+
     // Public API
     return {
-        initHapp: initHapp,
-        getHappUrl: getHappUrl,
-        getHappDna: getHappDna
+        initHapp,
+        getHappUrl,
+        getHappDna,
+        insertScripts,
     }
 })();
 
 
-/**
- * Adds a script that imports hClient and overrides the window web client.
- * Effectively enables a holochain app to be holo compatible
- *
- * @param {string} html Html to add tag to
- * @param {string} url hostname (with protocol and port, e.g. //test.holo.host:4141")
- * @return {string} Html with new script tag inserted at the top level
- */
-const insertScripts = (html, url) => {
-    parser = new DOMParser();
-    doc = parser.parseFromString(html, "text/html");
 
-    let script = doc.createElement("script");
-    script.src = "hClient.js"
-    script.innerHTML = `hClient.overrideWebClient(${url})`;
-
-    doc.head.appendChild(script);
-    return doc.documentElement.outerHTML
-}
 
 console.log("hQuery loaded");


### PR DESCRIPTION
This PR starts to spec out what is needed to integrate with hc-web-client on the client side and with the interceptor on the host side. 

On the client side the idea is that the UI developer should not have to care if the app is being used for Holochain or Holo. All calls should be made to hc-web-client in both cases. The Holo loader deals with this by injecting a script ([web/hClient.js]) which wraps the window hc-web-client and ensures it connects to the correct URL, provides pre/post call hooks and a postConnect hook.

In the pre-call hook this is where the signing of the calls will take place.

In the post-call hook this is where signing of responses for the service logger will happen and Unauthorized Access responses will be intercepted to redirect to the login/key generating page.

In the postConenct callback a new callback will be added to the existing RPC websocket connection which allows the interceptor to request the client to sign and entry before it is committed. 

